### PR TITLE
fix(packaging): bundle data dirs in wheel + robust path resolution

### DIFF
--- a/csk/commands/exercises.py
+++ b/csk/commands/exercises.py
@@ -13,8 +13,9 @@ from csk.commands.progress import load_progress, save_progress, EXERCISES
 
 console = Console()
 
-EXERCISES_DIR = Path(__file__).parent.parent.parent / "exercises"
-TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+from csk.resources import exercises_dir
+
+EXERCISES_DIR = exercises_dir() or Path(__file__).parent.parent.parent / "exercises"
 
 
 def generate_html(progress: dict) -> str:

--- a/csk/commands/init.py
+++ b/csk/commands/init.py
@@ -7,16 +7,32 @@ import click
 from rich.console import Console
 from rich.tree import Tree
 
+from csk.resources import templates_dir, agents_dir
+
 console = Console()
 
-TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+TEMPLATE_DIR = templates_dir()
 
 
 def get_template_content(name: str) -> str:
-    """Get template content, falling back to embedded defaults."""
-    template_path = TEMPLATE_DIR / name
-    if template_path.exists():
-        return template_path.read_text()
+    """Get template content, falling back to embedded defaults.
+
+    Template names map to the templates/ directory structure:
+    - "skill-<name>.md"  → templates/.claude/skills/<name>/SKILL.md
+    - "rule-<name>.md"   → templates/.claude/rules/<name>.md
+    - anything else      → templates/<name>
+    """
+    if TEMPLATE_DIR is not None:
+        if name.startswith("skill-") and name.endswith(".md"):
+            skill_name = name[len("skill-"):-len(".md")]
+            template_path = TEMPLATE_DIR / ".claude" / "skills" / skill_name / "SKILL.md"
+        elif name.startswith("rule-") and name.endswith(".md"):
+            rule_name = name[len("rule-"):]
+            template_path = TEMPLATE_DIR / ".claude" / "rules" / rule_name
+        else:
+            template_path = TEMPLATE_DIR / name
+        if template_path.exists():
+            return template_path.read_text()
     return EMBEDDED_TEMPLATES.get(name, "")
 
 
@@ -1014,9 +1030,9 @@ def init(project_name: str, force: bool):
     for filepath, content in files.items():
         (project_path / filepath).write_text(content)
 
-    # Copy agent files from CSK repo
-    csk_agents_dir = Path(__file__).parent.parent.parent / ".claude" / "agents"
-    if csk_agents_dir.exists():
+    # Copy agent files (works in both repo and pip-installed layouts)
+    csk_agents_dir = agents_dir()
+    if csk_agents_dir is not None:
         for agent_file in csk_agents_dir.glob("*.md"):
             dest = project_path / ".claude" / "agents" / agent_file.name
             shutil.copy2(agent_file, dest)

--- a/csk/commands/upgrade_project.py
+++ b/csk/commands/upgrade_project.py
@@ -11,9 +11,10 @@ from rich.table import Table
 
 console = Console()
 
-# Get templates from the installed package
-# Templates are at package root (../.. from commands/), not inside csk/
-TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
+from csk.resources import templates_dir
+
+# Works in both repo layout and pip-installed layout (csk/_data/templates)
+TEMPLATE_DIR = templates_dir() or Path(__file__).parent.parent.parent / "templates"
 
 
 def get_template_files() -> dict[str, Path]:
@@ -88,7 +89,18 @@ def upgrade_project(check: bool, force: bool, backup: bool, skill: tuple) -> Non
     console.print(Panel.fit("[bold cyan]CSK2 Project Upgrade[/]", border_style="cyan"))
     console.print()
 
+    if not TEMPLATE_DIR.is_dir():
+        console.print("[red]Error:[/red] Template directory not found.")
+        console.print(f"[dim]Looked in: {TEMPLATE_DIR}[/]")
+        console.print("[dim]Reinstall CSK: pip install --upgrade git+https://github.com/Simple-Bookings/claude-starter-kit.git[/]")
+        return
+
     template_files = get_template_files()
+
+    if not template_files:
+        console.print("[yellow]Warning:[/yellow] No template files found — nothing to compare.")
+        console.print(f"[dim]Template dir: {TEMPLATE_DIR}[/]")
+        return
 
     # Filter to specific skills if requested
     if skill:

--- a/csk/commands/workshop.py
+++ b/csk/commands/workshop.py
@@ -17,8 +17,10 @@ from csk.commands.progress import load_progress, save_progress, EXERCISES
 
 console = Console()
 
-WORKSHOP_DIR = Path(__file__).parent.parent.parent / "workshop"
-EXERCISES_DIR = Path(__file__).parent.parent.parent / "exercises"
+from csk.resources import workshop_dir, exercises_dir
+
+WORKSHOP_DIR = workshop_dir() or Path(__file__).parent.parent.parent / "workshop"
+EXERCISES_DIR = exercises_dir() or Path(__file__).parent.parent.parent / "exercises"
 PID_FILE = Path("/tmp/csk-workshop.pid")
 
 

--- a/csk/resources.py
+++ b/csk/resources.py
@@ -1,0 +1,60 @@
+"""Locate CSK data directories in both repo and pip-installed layouts.
+
+When running from a git clone (or `pip install -e .`), data directories
+(templates/, workshop/, exercises/, .claude/agents/) live at the repo root.
+
+When installed from a wheel, they are bundled inside the package at
+csk/_data/ (see [tool.hatch.build.targets.wheel.force-include] in
+pyproject.toml).
+"""
+
+from pathlib import Path
+
+_PACKAGE_DIR = Path(__file__).parent
+_REPO_ROOT = _PACKAGE_DIR.parent
+_BUNDLED_DATA = _PACKAGE_DIR / "_data"
+
+
+def find_data_dir(name: str) -> Path | None:
+    """Return the path to a data directory, or None if not found.
+
+    Checks the repo layout first (git clone / editable install),
+    then the bundled package data (wheel install).
+    """
+    repo_path = _REPO_ROOT / name
+    if repo_path.is_dir():
+        return repo_path
+
+    bundled_path = _BUNDLED_DATA / name
+    if bundled_path.is_dir():
+        return bundled_path
+
+    return None
+
+
+def templates_dir() -> Path | None:
+    """Project templates (skills, rules, CLAUDE.md, etc.)."""
+    return find_data_dir("templates")
+
+
+def workshop_dir() -> Path | None:
+    """Workshop materials (slides, kompendium, presenter, handout)."""
+    return find_data_dir("workshop")
+
+
+def exercises_dir() -> Path | None:
+    """Hands-on exercise markdown files."""
+    return find_data_dir("exercises")
+
+
+def agents_dir() -> Path | None:
+    """Agent profile markdown files."""
+    repo_path = _REPO_ROOT / ".claude" / "agents"
+    if repo_path.is_dir():
+        return repo_path
+
+    bundled_path = _BUNDLED_DATA / "agents"
+    if bundled_path.is_dir():
+        return bundled_path
+
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ csk = "csk.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["csk"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"templates" = "csk/_data/templates"
+"workshop" = "csk/_data/workshop"
+"exercises" = "csk/_data/exercises"
+".claude/agents" = "csk/_data/agents"
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
Found by test-driving the published kit as a fresh pip-install user.

## Bugs fixed
1. **`csk workshop` crashed** — workshop/ not in the wheel
2. **`csk init` generated stale content** — template name lookup never matched the real `templates/.claude/` structure, so the embedded (outdated) onboarding skill was used and agent profiles were missing
3. **`csk upgrade-project` false positive** — reported "all up to date" when the template dir didn't exist at all
4. **All data dirs missing from wheel** — only `csk/` was packaged

## Fix
- `[tool.hatch.build.targets.wheel.force-include]` bundles templates/, workshop/, exercises/, and agents as `csk/_data/*`
- New `csk/resources.py` resolves data dirs in both repo layout and wheel layout
- Template-name mapping fixed in `init.py`
- Explicit error in `upgrade-project` when templates are missing

## Verified
- Wheel contains all data dirs (18 templates, 7 workshop, 10 exercises, 7 agents)
- Fresh wheel install: `csk init` produces new onboarding skill + 7 agents, `csk workshop` serves, `csk upgrade-project --check` compares 16 files
- Test suite: 22/22 passing

This has been developed by Cura AI Team